### PR TITLE
Changed shebang to check $PATH for bash instead of assuming /bin/bash

### DIFF
--- a/lb
+++ b/lb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set your personal data here:
 rssfile="rss.xml"


### PR DESCRIPTION
Bash is not always located in /bin/bash. Modified script to check $PATH to see where bash is. This allows the script to run on *BSD and Solaris systems. Also improves Mac OS X compatibility.

See https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash/21613044