### PR TITLE
Added check just in case $EDITOR environment variable is not set

### DIFF
--- a/lb
+++ b/lb
@@ -11,6 +11,11 @@ dir=$(pwd)
 draftdir="$dir"/blog/.drafts
 blogdir="$dir"/blog
 
+# Set vi if $EDITOR not set
+if [ -z $EDITOR ];
+	then EDITOR="vi";
+fi;
+
 # See other variables defined later, such as `header` and `webdate` for more customizability.
 
 getHelp() { \


### PR DESCRIPTION
Non-Linux based Unix systems don't always have the $EDITOR environment variable set. All Unix systems will have vi installed out of the box since it's a part of POSIX standards. 

I encountered this issue when running the script on OpenBSD, since OpenBSD doesn't set $EDITOR out of the box.

Another way to handle this would be to throw an exception at script execution stating that you need $EDITOR set.

EDIT: I should clarify I know it says that $EDITOR needs to be set in the README, I just found it interesting that there was nothing notifying the user of this at runtime.