### PR TITLE
Bug fixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+#exclude blog
+/blog
+!/blog/this-is-what-a-post-looks-like.html

--- a/lb
+++ b/lb
@@ -44,8 +44,10 @@ getTitle() { \
 
 postNew() { \
 	mkdir -p "$draftdir"
-	echo -e "<h2 id='$url'>$title</h2>\n<small>[<a href=\"$blogfile#$url\">link</a>&mdash;<a href=\"blog/$url.html\">standalone</a>]</small>\n\n<++>" >> "$draftdir"/$url.html && $EDITOR "$draftdir"/$url.html
-	}
+	[ -f "$draftdir"/"$url"'.html' ] || \
+	echo -e "<h2 id='$url'>$title</h2>\n<small>[<a href=\"$blogfile#$url\">link</a>&mdash;<a href=\"blog/$url.html\">standalone</a>]</small>\n\n<++>" >> "$draftdir"/$url.html
+	$EDITOR "$draftdir"/$url.html
+}
 
 finalize() { \
 	url=$(grep -o "<h2 id='\(.\)*'>" "$draftdir"/"$chosen" | cut -d "'" -f2)

--- a/lb
+++ b/lb
@@ -33,11 +33,12 @@ listandReturn() { \
 getTitle() { \
 	echo "Post will be stored as draft in $draftdir until finalized."
 	read -rp "Give a title for your post: " title
+	title=$(echo "$title" | tr -d '[=/=]' | tr -d '[=\=]')
 	url=$(echo "$title" | tr -d '[:punct:]' | tr " " "-" | tr '[:upper:]' '[:lower:]')
 
 	[ -z $url ] && echo "Error: Empty title!" && return 0;
 
-	grep "$url" "$blogfile" &>/dev/null && lbdupnum=1 && while [ grep "$url" "$blogfile" ]; do lbdupnum=$((lbdupnum+1)); done
+	grep "id='$url'" "$blogfile" &>/dev/null && lbdupnum=1 && while [ grep "$url" "$blogfile" ]; do lbdupnum=$((lbdupnum+1)); done
 	[ ! -z ${lbdupnum+x} ] && url="$url"-"$lbdupnum"
 	return 0
 	}
@@ -51,7 +52,7 @@ postNew() { \
 
 finalize() { \
 	url=$(grep -o "<h2 id='\(.\)*'>" "$draftdir"/"$chosen" | cut -d "'" -f2)
-	title=$(grep -o "<h2 id='\(.\)*h2>" "$draftdir"/"$chosen" | sed -e 's/<[^>]*>//g')
+	title=$(grep -o "<h2 id='\(.\)*h2>" "$draftdir"/"$chosen" | sed -E 's/<[^>]*>//g')
 	echo "AddDescription \"$title\" $chosen" >> "$blogdir"/.htaccess
 	rssdate=$(date '+%a, %d %b %Y %H:%M:%S %z')
 	webdate=$(date '+%a, %d %b %Y %H:%M:%S %z')
@@ -90,6 +91,6 @@ case "$1" in
 	discard) listandReturn "$draftdir/*.html" discard && discard ;;
 	finalize) listandReturn "$draftdir" finalize && finalize ;;
 	delete) listandReturn "$blogdir/*.html" delete && delete ;;
-	edit) listandReturn "$draftdir/*.html" edit && vim "$chosen" ;;
+	edit) listandReturn "$draftdir/*.html" edit && $EDITOR "$chosen" ;;
 	*) getHelp ;;
 esac

--- a/lb
+++ b/lb
@@ -34,6 +34,9 @@ getTitle() { \
 	echo "Post will be stored as draft in $draftdir until finalized."
 	read -rp "Give a title for your post: " title
 	url=$(echo "$title" | tr -d '[:punct:]' | tr " " "-" | tr '[:upper:]' '[:lower:]')
+
+	[ -z $url ] && echo "Error: Empty title!" && return 0;
+
 	grep "$url" "$blogfile" &>/dev/null && lbdupnum=1 && while [ grep "$url" "$blogfile" ]; do lbdupnum=$((lbdupnum+1)); done
 	[ ! -z ${lbdupnum+x} ] && url="$url"-"$lbdupnum"
 	return 0

--- a/lb
+++ b/lb
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Set your personal data here:
 rssfile="rss.xml"


### PR DESCRIPTION
**List of fixes**
- Change sh to bash in case of other distros that use dash as sh like Debian or Ubuntu instead of symlinking sh to bash.
- Creating a blog post starting with only '/' is deleted with tr, or just in general making a title without an empty string. Check if the url is null and make it exit, I can make it loop by just going to the getTitle function but knowing you like UNIX programs, they usually fail if you don't get it correct.
- You cannot call your blog title 'ass' because it collides with normal html stuff like 'class'. So it now greps for "id='$url'", now you can have a blog post with the title 'ass'.
- Creating a new file with a draft of the same filename, just echos more text. Now goes straight to editing the file.
- Use your preferred editor instead of vim.
- Remove slashes from titles, the downside is that you cannot make "GNU/Linux is good." as a blogpost as it would default to "GNULinux is good".
- Fix typo of this line
```
title=$(grep -o "<h2 id='\(.\)*h2>" "$draftdir"/"$chosen" | sed -e 's/<[^>]*>//g')
to
title=$(grep -o "<h2 id='\(.\)*h2>" "$draftdir"/"$chosen" | sed -E 's/<[^>]*>//g')
```
-e executes script, -E is for expression

**Misc**
Non-example files in blog folder and drafts are not pushed for other developer's sake.