### PR TITLE
Made delete() safer with <!-- LB --> inside divs

### DIFF
--- a/lb
+++ b/lb
@@ -57,7 +57,7 @@ confirm() { read -erp "Really $1 \"$base\"? (y/N) " choice && echo "$choice" | g
 
 delete() { \
 	sed -i "/<item/{:a;N;/<\\/item>/!ba};/#$base.html<\\/guid/d" $rssfile
-	sed -i "/<div/{:a;N;/<\\/div>/!ba};/id='$base'/d" $blogfile
+	sed -i "/<div class='entry'>/{:a;N;/<\\/div>/!ba};/id='$base'/d" $blogfile
 	sed -i "/<li>.*<a href=\"blog\\/$base.html\">/d" $indexfile
 	rm "$webdir/blog/$basefile" 2>/dev/null && printf "Old blog entry removed.\\n" ;}
 


### PR DESCRIPTION
Previously when using ```delete()``` with ```<!-- LB -->``` inside div tags, the tags it was placed in also got deleted, meaning a bunch of non-blog content was deleted too. By specifying ```<div class='entry'>```, only the div tags containing blog entries (```<div class='entry'>```) are deleted.

In other words, using the function on a ```$blogfile``` containing something like:
```
<div class="content">
<h1>My Blog</h1>
<!-- LB -->
<div class='entry'>
...
</div>
</div>
```
Would result in the entire ```<div class="content">``` tag and contents being deleted.