### PR TITLE
Minor patch to fix "Old entry removed" when publishing

### DIFF
--- a/lb
+++ b/lb
@@ -29,7 +29,7 @@ newpost() { read -erp "Give a title for your post:
 listandReturn() {
 	case "$(ls "$1" | wc -l)" in
 		0) echo "There's nothing to $2." && exit 1 ;;
-		1) number=1 ;;
+		1) number=1 && echo "There's only one entry to $2. Defaulting selection to $(ls -rc "$1" | awk -F '/' '{print $NF}')" ;;
 		*) ls -rc "$1" | awk -F '/' '{print $NF}' | nl
                 read -erp "Pick an entry by number to $2, or press Ctrl-C to cancel. " number ;;
 	esac
@@ -38,7 +38,7 @@ listandReturn() {
 }
 
 publish() { \
-	delete
+	delete draft
 	htaccessentry=$(grep "$basefile" "$webdir/blog/.htaccess")
 	realname="$(echo "$htaccessentry" | cut -d'"' -f2)"
 	rssdate="$(grep "$basefile" blog/.htaccess | sed "s/.*\.html\"* *#*//g" | tr -d '\n')"
@@ -63,7 +63,7 @@ delete() { \
 	sed -i "/<item/{:a;N;/<\\/item>/!ba};/#$base<\\/guid/d" "$rssfile"
 	sed -i "/<div class='entry'>/{:a;N;/<\\/div>/!ba};/id='$base'/d" "$blogfile"
 	sed -i "/<li>.*<a href=\"blog\\/$base.html\">/d" "$indexfile"
-	rm -f "$webdir/blog/$basefile" && printf "Old blog entry removed.\\n" ;}
+	rm -f "$webdir/blog/$basefile" && [[ "$1" != "draft" ]] && printf "Old blog entry removed.\\n";}
 
 revise() { awk '/^<small>\[/{flag=1;next}/<footer>/{flag=0}flag' "$webdir/blog/$chosen" > "$webdir/blog/.drafts/$basefile"
 	"$EDITOR" "$webdir/blog/.drafts/$basefile"

--- a/lb
+++ b/lb
@@ -30,7 +30,7 @@ listandReturn() {
 	printf "Listing contents of %s\\n" "$1"
 	case "$(ls "$1" | wc -l)" in
 		0) echo "There's nothing to $2." && exit 1 ;;
-		1) number=1 && printf "There's only one blog entry to %s.\\nDefaulting selection to %s\\n" "$2" "$(ls -rc "$1" | awk -F '/' '{print $NF}')" ;;
+		1) number=1 && printf "There's only one entry to %s.\\nDefaulting selection to %s\\n" "$2" "$(ls -rc "$1" | awk -F '/' '{print $NF}')" ;;
 		*) ls -rc "$1" | awk -F '/' '{print $NF}' | nl
                 read -erp "Pick an entry by number to $2, or press Ctrl-C to cancel. " number ;;
 	esac

--- a/lb
+++ b/lb
@@ -27,9 +27,10 @@ newpost() { read -erp "Give a title for your post:
 	$EDITOR "$webdir/blog/.drafts/$url.html" ;}
 
 listandReturn() {
+	printf "Listing contents of %s\\n" "$1"
 	case "$(ls "$1" | wc -l)" in
 		0) echo "There's nothing to $2." && exit 1 ;;
-		1) number=1 && echo "There's only one entry to $2. Defaulting selection to $(ls -rc "$1" | awk -F '/' '{print $NF}')" ;;
+		1) number=1 && printf "There's only one blog entry to %s.\\nDefaulting selection to %s\\n" "$2" "$(ls -rc "$1" | awk -F '/' '{print $NF}')" ;;
 		*) ls -rc "$1" | awk -F '/' '{print $NF}' | nl
                 read -erp "Pick an entry by number to $2, or press Ctrl-C to cancel. " number ;;
 	esac


### PR DESCRIPTION
When running `./lb p` and **only one entry was listed**,  lb outputted "Old entry removed" ...
With this patch lb will only print "Old entry removed" if what is to be deleted is not a draft.
Also, with this patch, listing content is now verbose even if there's only one listed entry.

The output now looks like this:
```
$ ./lb p
Listing contents of /path/to/lb/blog/.drafts/
There's only one blog entry to publish.
Defaulting selection to example.html
```

Same with delete and every function that calls listandReturn().